### PR TITLE
Allow to exclude dirs from being recursed into

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,8 +6,9 @@ An easy way to require all files within a directory.
 
 ```js
 var controllers = require('require-all')({
-  dirname: __dirname + '/controllers',
-  filter: /(.+Controller)\.js$/,
+  dirname     :  __dirname + '/controllers',
+  filter      :  /(.+Controller)\.js$/,
+  excludeDirs :  /^\.(git|svn)$/
 });
 
 // controllers now is an object with references to all modules matching the filter

--- a/index.js
+++ b/index.js
@@ -4,12 +4,20 @@ module.exports = function requireAll(options) {
   var files   = fs.readdirSync(options.dirname);
   var modules = {};
 
+  function excludeDirectory(dirname) {
+    return options.excludeDirs && dirname.match(options.excludeDirs);
+  }
+
   files.forEach(function(file) {
     var filepath = options.dirname + '/' + file;
     if (fs.statSync(filepath).isDirectory()) {
+
+      if (excludeDirectory(file)) return;
+
       modules[file] = requireAll({
-        dirname: filepath,
-        filter: options.filter
+        dirname     :  filepath,
+        filter      :  options.filter,
+        excludeDirs :  options.excludeDirs
       });
 
     } else {

--- a/test/filterdir/.svn/stuff.js
+++ b/test/filterdir/.svn/stuff.js
@@ -1,0 +1,1 @@
+module.exports = { gute: 'nacht' };

--- a/test/filterdir/root.js
+++ b/test/filterdir/root.js
@@ -1,0 +1,1 @@
+module.exports = { guten: 'tag' };

--- a/test/filterdir/sub/hello.js
+++ b/test/filterdir/sub/hello.js
@@ -1,0 +1,1 @@
+module.exports = { guten: 'abend' };

--- a/test/test.js
+++ b/test/test.js
@@ -36,3 +36,32 @@ if (process.version > 'v0.6.0') {
     }
   });
 }
+
+var unfiltered = requireAll({
+  dirname: __dirname + '/filterdir',
+  filter: /(.+)\.js$/
+});
+
+assert(unfiltered['.svn']);
+assert(unfiltered['root']);
+assert(unfiltered['sub']);
+
+var excludedSvn = requireAll({
+  dirname: __dirname + '/filterdir',
+  filter: /(.+)\.js$/,
+  excludeDirs: /^\.svn$/
+});
+
+assert.equal(excludedSvn['.svn'], undefined);
+assert.ok(excludedSvn['root']);
+assert.ok(excludedSvn['sub']);
+
+var excludedSvnAndSub = requireAll({
+  dirname: __dirname + '/filterdir',
+  filter: /(.+)\.js$/,
+  excludeDirs: /^(\.svn|sub)$/
+});
+
+assert.equal(excludedSvnAndSub['.svn'], undefined);
+assert.ok(excludedSvnAndSub['root']);
+assert.equal(excludedSvnAndSub['sub'], undefined);


### PR DESCRIPTION
- excludeDirs regex can be specified to exclude directories from being recursed into
- added fixtures test/filterdir and related tests inside tests.js
- updated readme to show this options

Example:

``` js
var controllers = require('require-all')({
  dirname     :  __dirname + '/controllers',
  filter      :  /(.+Controller)\.js$/,
  excludeDirs :  /^\.(git|svn)$/
});
```

This feature becomes especially important if you are stuck with a version of svn that adds '.svn' folders everywhere. In order to prevent exports['.svn'] to be added, I can now exclude it.

This would also be of use if I'd like to make my `index.js` auto require all modules in lib folders, etc., In this case I'd need to be able to exclude '.git' and 'node_modules'.
