### PR TITLE
Added options.sort, and allow default values in options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,21 +5,88 @@ An easy way to require all files within a directory.
 ## Usage
 
 ```js
-var controllers = require('require-all')({
-  dirname     :  __dirname + '/controllers',
-  filter      :  /(.+Controller)\.js$/,
-  excludeDirs :  /^\.(git|svn)$/
-});
-
-// controllers now is an object with references to all modules matching the filter
-// for example:
-// { HomeController: function HomeController() {...}, ...}
+require('require-all')(dirname[, options]);
 ```
 
-## Advanced usage
+which returns a object containing all files required.
 
-If your objective is to simply require all .js and .json files in a directory you can just pass a string to require-all:
+`options`, optional, a Object to change default behavior.
 
-``` js
-var libs = require('require-all')(__dirname + '/lib');
+See test for more examples.
+
+### options.filter
+
+a RegExp used to filter files.
+
+**Example**
+
+`/(.+Controller)\.js$/`
+
+**Default**
+
+`/^(.+)\.js(on)?$/`
+
+**Note**
+
+First match of the expression will be used as the key in the returning object.
+
+
+### options.excludeDirs
+
+a RegExp used to exclude directories.
+
+**Example**
+
+`/^/`
+
+**Default**
+
+`/^\.(git|svn)$/`
+
+**Note**
+
+When give `false`, it will include all sub directories, while `true` will
+exclude all.
+
+### options.sort
+
+a Function used to sort files before require them.
+
+**Example**
+
+```js
+
+funcion(leftHandName, rightHandName) {
+  if (leftHandName < rightHandName)
+    return -1;
+  return 1;
+}
 ```
+
+**Default**
+
+`undefined`
+
+**Note**
+
+This may not work as desired when file name is a number.
+
+## Update from 0.0.8
+
+require-all still take old options format, and behave the same as before. But it
+may be changed in the future.
+
+Update to 0.1.0 will only take seconds:
+
+1. if you're not using options, nothing need to be done;
+2. otherwise, move options.dirname to first argument;
+3. update `excludeDirs`
+
+  1. remove it if you are using default value;
+  2. _or_ set it to `true`, if you want to exclude all dirs;
+  3. _or_ set it to `false`, if you want to include all dirs.
+
+4. update `filter`
+
+  1. remove it if you are using default value;
+  2. _or_ leave it as it with your setting.

--- a/index.js
+++ b/index.js
@@ -14,8 +14,6 @@ function extend(obj, ext) {
 
 function requireAll(dirname, options) {
 
-  options = extend(options || {}, defaultOptions);
-
   var files = fs.readdirSync(dirname);
   var modules = {};
 
@@ -40,10 +38,12 @@ function requireAll(dirname, options) {
 }
 
 module.exports = function(dirname, options) {
-  if (typeof dirname == 'object')
-    return requireAll(dirname.dirname, {
+  if (typeof dirname == 'object') {
+    options = {
       filter: dirname.filter,
       excludeDirs: dirname.excludeDirs || false
-    });
-  return requireAll(dirname, options);
+    };
+    dirname = dirname.dirname;
+  }
+  return requireAll(dirname, extend(options || {}, defaultOptions));
 };

--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ module.exports = function requireAll(options) {
     return options.excludeDirs && dirname.match(options.excludeDirs);
   }
 
+  if (options.sort)
+    files.sort(typeof options.sort == 'function' ? options.sort : undefined);
+
   files.forEach(function (file) {
     var filepath = options.dirname + '/' + file;
     if (fs.statSync(filepath).isDirectory()) {
@@ -25,7 +28,8 @@ module.exports = function requireAll(options) {
       modules[file] = requireAll({
         dirname: filepath,
         filter: options.filter,
-        excludeDirs: options.excludeDirs
+        excludeDirs: options.excludeDirs,
+        sort: options.sort
       });
 
     } else {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "author": "Felix Geisendörfer <felix@debuggable.com> (http://debuggable.com/)",
   "name": "require-all",
   "description": "An easy way to require all files within a directory.",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "scripts": {
-    "test": "node test/test.js"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -16,13 +16,12 @@
       "url": "https://github.com/felixge/node-require-all/blob/master/License"
     }
   ],
-  "main": "./index",
+  "main": "./index.js",
   "engines": {
-    "node": "*"
+    "node": ">0.6"
   },
-  "dependencies": {},
   "devDependencies": {
-    "semver": "~2.1.0"
-  },
-  "optionalDependencies": {}
+    "blanket": "^1.1.6",
+    "should": "^3.3.1"
+  }
 }

--- a/test/filterdir/.svn/stuff.js
+++ b/test/filterdir/.svn/stuff.js
@@ -1,1 +1,1 @@
-module.exports = { gute: 'nacht' };
+module.exports = true

--- a/test/filterdir/root.js
+++ b/test/filterdir/root.js
@@ -1,1 +1,1 @@
-module.exports = { guten: 'tag' };
+module.exports = true;

--- a/test/filterdir/sub/hello.js
+++ b/test/filterdir/sub/hello.js
@@ -1,1 +1,1 @@
-module.exports = { guten: 'abend' };
+module.exports = true;

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require should

--- a/test/order/1-1.js
+++ b/test/order/1-1.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/test/order/2-1.js
+++ b/test/order/2-1.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/test/order/3-1.js
+++ b/test/order/3-1.js
@@ -1,0 +1,1 @@
+module.exports = 3;


### PR DESCRIPTION
sort option is added because `fs.readdir()` doesn't guarantee the [order](http://stackoverflow.com/questions/8977441/does-readdir-guarantee-an-order), which shouldn't be a problem for most use cases, but when use `requireAll()` to load a bunch of routes for express, wrong include order may cause routing priority disorder:

eg. 

routes/a.js
```
module.exports = { method: 'get', match: /^\//, handler: function(req, res) { res.send('a') } };
```

routes/b.js
```
module.exports = { method: 'get', match: /^\//, handler: function(req, res) { res.send('b') } };
```

routes.js
```
var routes = requireAll(__dirname + '/routes');
for (var name in routes) {
  var route = routes[name];
  app[route.method].apply(app, route.match, route.handler);
}
```

Alhough it could be solved by using a explicit `Object.keys().sort()` to fix the problem, which is not clean, especially for recursive cases.

I also added new require-all signature `requireAll(dirname, options)`, updated document and rewrite tests using mocha (All these could be removed from the pull request if you want)