### PR TITLE
Filter updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,10 +35,9 @@ module.exports = function requireAll(options) {
       });
 
     } else {
-      var match = file.match(filter);
-      if (!match) return;
-
-      modules[map(match[1], filepath)] = resolve(require(filepath));
+      // Support old regex filters or array of filenames filter
+      if((Array.isArray(filter) && filter.indexOf(file) === -1) || file.match(filter)) return;
+      modules[map(file, filepath)] = resolve(require(filepath));
     }
   });
 


### PR DESCRIPTION
Fixing a bug with the former use of String.match.

We shouldn't be using anything returned from String.match to map the file name to its content.  We should just use the file name as is done in line 29 already by default.  The current behavior is mapping the index of the regex match to the loaded contents which is a bug.  I am having multiple files fail to load contents because their is overlap.

Further, this adds support for users to pass in array of strings to filter on.

See 
https://github.com/felixge/node-require-all/issues/27