### PR TITLE
Added support for relative paths, `__dirname` no longer necessary

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,9 @@ This file is a manually maintained list of changes for each release. Feel free
 to add your changes here when sending pull requests. Also send corrections if
 you spot any mistakes.
 
+## v2.1.0 (2016-12-6)
+* Added info about module as argument to resolve function
+
 ## v2.0.0 (2015-10-17)
 
 * Add "recursive" argument to control directory recursion #21

--- a/Changes.md
+++ b/Changes.md
@@ -4,8 +4,8 @@ This file is a manually maintained list of changes for each release. Feel free
 to add your changes here when sending pull requests. Also send corrections if
 you spot any mistakes.
 
-## v2.1.0 (2016-12-6)
-* Added info about module as argument to resolve function
+## Unreleased
+* Added name and path to resolve function
 
 ## v2.0.0 (2015-10-17)
 

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ to add your changes here when sending pull requests. Also send corrections if
 you spot any mistakes.
 
 ## Unreleased
+* Adding __dirname before the directory not longer necessary
 * Added name and path to resolve function
 
 ## v2.0.0 (2015-10-17)

--- a/Readme.md
+++ b/Readme.md
@@ -10,9 +10,9 @@ An easy way to require all files within a directory.
 
 ```js
 var controllers = require('require-all')({
-  dirname     :  __dirname + '/controllers',
-  filter      :  /(.+Controller)\.js$/,
-  excludeDirs :  /^\.(git|svn)$/,
+  dirname     : 'controllers',
+  filter      : /(.+Controller)\.js$/,
+  excludeDirs : /^\.(git|svn)$/,
   recursive   : true
 });
 
@@ -26,7 +26,7 @@ var controllers = require('require-all')({
 If your objective is to simply require all .js and .json files in a directory you can just pass a string to require-all:
 
 ``` js
-var libs = require('require-all')(__dirname + '/lib');
+var libs = require('require-all')('lib');
 ```
 
 ### Constructed object usage
@@ -35,8 +35,8 @@ If your directory contains files that all export constructors, you can require t
 
 ```js
 var controllers = require('require-all')({
-  dirname     :  __dirname + '/controllers',
-  filter      :  /(.+Controller)\.js$/,
+  dirname     : 'controllers',
+  filter      : /(.+Controller)\.js$/,
   resolve     : function (Controller, name, path) {
     console.log('Constructor of `%s` from `%s` executed', name, path);
     return new Controller();
@@ -50,8 +50,8 @@ If your directory contains files where the names do not match what you want in t
 
 ```js
 var controllers = require('require-all')({
-  dirname :  __dirname + '/controllers',
-  filter  :  /(.+Controller)\.js$/,
+  dirname : 'controllers',
+  filter  : /(.+Controller)\.js$/,
   map     : function (name, path) {
     return name.replace(/_([a-z])/g, function (m, c) {
       return c.toUpperCase();

--- a/Readme.md
+++ b/Readme.md
@@ -37,21 +37,11 @@ If your directory contains files that all export constructors, you can require t
 var controllers = require('require-all')({
   dirname     :  __dirname + '/controllers',
   filter      :  /(.+Controller)\.js$/,
-  resolve     : function (Controller, moduleInfo) {
-    console.log('Constructor of `%s` from `%s` executed', moduleInfo.name, moduleInfo.path);
+  resolve     : function (Controller, name, path) {
+    console.log('Constructor of `%s` from `%s` executed', name, path);
     return new Controller();
   }
 });
-
-// moduleInfo parameter is an object containing info about the required module:
-name  The name converted by the map function
-dir   Directory of the file
-file  Filename
-path  Full path to file
-{ name: 'TestController',
-  dir: '/path-to-folder/',
-  file: 'onearg.js',
-  path: '/path-to-folder/TestController.js' }
 ```
 
 ### Alternative property names

--- a/Readme.md
+++ b/Readme.md
@@ -37,10 +37,21 @@ If your directory contains files that all export constructors, you can require t
 var controllers = require('require-all')({
   dirname     :  __dirname + '/controllers',
   filter      :  /(.+Controller)\.js$/,
-  resolve     : function (Controller) {
+  resolve     : function (Controller, moduleInfo) {
+    console.log('Constructor of `%s` from `%s` executed', moduleInfo.name, moduleInfo.path);
     return new Controller();
   }
 });
+
+// moduleInfo parameter is an object containing info about the required module:
+name  The name converted by the map function
+dir   Directory of the file
+file  Filename
+path  Full path to file
+{ name: 'TestController',
+  dir: '/path-to-folder/',
+  file: 'onearg.js',
+  path: '/path-to-folder/TestController.js' }
 ```
 
 ### Alternative property names

--- a/index.js
+++ b/index.js
@@ -40,9 +40,9 @@ module.exports = function requireAll(options) {
       var match = file.match(filter);
       if(!match) return;
 
-      var name = map(match[1], filepath);
+      var name = map(match[1], filePath);
 
-      modules[name] = resolve(require(filepath), name, filepath);
+      modules[name] = resolve(require(filePath), name, filePath);
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
-var fs = require('fs');
+var fs = require('fs'), path = require('path');
+
+var parentDir = path.dirname(module.parent.filename); // Directory of the module from which requireAll is called from
 
 var DEFAULT_EXCLUDE_DIR = /^\./;
 var DEFAULT_FILTER = /^([^\.].*)\.js(on)?$/;
@@ -14,29 +16,29 @@ module.exports = function requireAll(options) {
   var map = options.map || identity;
 
   function excludeDirectory(dirname) {
-    return !recursive ||
-      (excludeDirs && dirname.match(excludeDirs));
+    return !recursive || (excludeDirs && dirname.match(excludeDirs));
   }
+  
+  var dirPath = dirname;
+  if(!path.isAbsolute(dirname)) dirPath = parentDir + '/' + dirname;
+  
+  var files = fs.readdirSync(dirPath);
+  files.forEach(function(file) {
+    var filePath = dirPath + '/' + file;
 
-  var files = fs.readdirSync(dirname);
+    if(fs.statSync(filePath).isDirectory()) {
+      if(excludeDirectory(file)) return;
 
-  files.forEach(function (file) {
-    var filepath = dirname + '/' + file;
-    if (fs.statSync(filepath).isDirectory()) {
-
-      if (excludeDirectory(file)) return;
-
-      modules[map(file, filepath)] = requireAll({
-        dirname: filepath,
+      modules[map(file, filePath)] = requireAll({
+        dirname: filePath,
         filter: filter,
         excludeDirs: excludeDirs,
         map: map,
         resolve: resolve
       });
-
     } else {
       var match = file.match(filter);
-      if (!match) return;
+      if(!match) return;
 
       var name = map(match[1], filepath);
 

--- a/index.js
+++ b/index.js
@@ -38,15 +38,9 @@ module.exports = function requireAll(options) {
       var match = file.match(filter);
       if (!match) return;
 
-      // Create an info object to pass to the resolve function
-      var moduleInfo = {
-        name: map(match[1], filepath),
-        dir: dirname,
-        file: file,
-        path: filepath
-      };
+      var name = map(match[1], filepath);
 
-      modules[moduleInfo.name] = resolve(require(filepath), moduleInfo);
+      modules[name] = resolve(require(filepath), name, filepath);
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -38,7 +38,15 @@ module.exports = function requireAll(options) {
       var match = file.match(filter);
       if (!match) return;
 
-      modules[map(match[1], filepath)] = resolve(require(filepath));
+      // Create an info object to pass to the resolve function
+      var module = {
+        name: map(match[1], filepath),
+        dir: dirname,
+        file: file,
+        path: filepath
+      };
+
+      modules[module.name] = resolve(require(module.path), module);
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -39,14 +39,14 @@ module.exports = function requireAll(options) {
       if (!match) return;
 
       // Create an info object to pass to the resolve function
-      var module = {
+      var moduleInfo = {
         name: map(match[1], filepath),
         dir: dirname,
         file: file,
         path: filepath
       };
 
-      modules[module.name] = resolve(require(module.path), module);
+      modules[moduleInfo.name] = resolve(require(filepath), moduleInfo);
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "require-all",
   "description": "An easy way to require all files within a directory.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Felix Geisendörfer <felix@debuggable.com> (http://debuggable.com/)",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "require-all",
   "description": "An easy way to require all files within a directory.",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "author": "Felix Geisendörfer <felix@debuggable.com> (http://debuggable.com/)",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",

--- a/test/test.js
+++ b/test/test.js
@@ -213,7 +213,7 @@ var resolvedValues = requireAll({
 assert.equal(resolvedValues.onearg, 'arg1');
 assert.equal(resolvedValues.twoargs, 'arg2');
 
-// Module info test, tests that the name is converted by the map function
+// Tests that the name is converted by the map function and path is defined
 var moduleInfos = [];
 var resolvedValues = requireAll({
   dirname: __dirname + '/resolved',
@@ -223,8 +223,11 @@ var resolvedValues = requireAll({
       return c.toUpperCase();
     });
   },
-  resolve: function (fn, moduleInfo) {
-    moduleInfos.push(moduleInfo);
+  resolve: function (fn, name, path) {
+    moduleInfos.push({
+      name: name,
+      path: path
+    });
     return fn('arg1', 'arg2');
   }
 });
@@ -232,10 +235,6 @@ var resolvedValues = requireAll({
 assert.equal(resolvedValues.ONEARG, 'arg1');
 assert.equal(resolvedValues.TWOARGS, 'arg2');
 assert.equal(moduleInfos[0].name, 'ONEARG');
-assert(moduleInfos[0].dir, 'moduleInfo.filepath undefined');
-assert.equal(moduleInfos[0].file, 'onearg.js');
-assert(moduleInfos[0].path, 'moduleInfo.filepath undefined');
+assert(moduleInfos[0].path, 'path undefined');
 assert.equal(moduleInfos[1].name, 'TWOARGS');
-assert(moduleInfos[1].dir, 'moduleInfo.filepath undefined');
-assert.equal(moduleInfos[1].file, 'twoargs.js');
-assert(moduleInfos[1].path, 'moduleInfo.filepath undefined');
+assert(moduleInfos[1].path, 'path undefined');

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,7 @@ var requireAll = require('..');
  * Recursively load .js files from the `controller` folder that end with `Controller`
  **/
 var controllers = requireAll({
-  dirname: 'controllers',
+  dirname: __dirname + '/controllers',
   filter: /(.+Controller)\.js$/
 });
 
@@ -37,7 +37,7 @@ assert.deepEqual(controllers, {
  * Non-recursively load .js files from the `controller` folder that end with `Controller`
  **/
 var controllersTop = requireAll({
-  dirname: 'controllers',
+  dirname: __dirname + '/controllers',
   filter: /(.+Controller)\.js$/,
   recursive: false
 });
@@ -62,7 +62,7 @@ assert.deepEqual(controllersTop, {
  * Replace `-C` for `_c` in the property name using the map option
  **/
 var controllersMap = requireAll({
-  dirname: 'controllers',
+  dirname: __dirname + '/controllers',
   filter: /(.+Controller)\.js$/,
   map: function (name) {
     return name.replace(/-([A-Z])/, function (m, c) {
@@ -98,7 +98,7 @@ assert.deepEqual(controllersMap, {
  * Replace `-C` for `_c` in the property name using the map option
  **/
 controllersMap = requireAll({
-  dirname: 'controllers',
+  dirname: __dirname + '/controllers',
   filter: /(.+Controller)\.js$/,
   map: function (name) {
     return name.replace(/-([A-Za-z])/, function (m, c) {
@@ -135,7 +135,7 @@ assert.deepEqual(controllersMap, {
  **/
 if(semver.gt(process.version, 'v0.6.0')) {
   var mydir = requireAll({
-    dirname: 'mydir'
+    dirname: __dirname + '/mydir'
   });
 
   var mydir_contents = {
@@ -165,7 +165,7 @@ if(semver.gt(process.version, 'v0.6.0')) {
  * Exclude dirs false
  **/
 var unfiltered = requireAll({
-  dirname: 'filterdir',
+  dirname: __dirname + '/filterdir',
   filter: /(.+)\.js$/,
   excludeDirs: false
 });
@@ -179,7 +179,7 @@ assert(unfiltered.sub);
  * Exclude .svn dirs
  **/
 var excludedSvn = requireAll({
-  dirname: 'filterdir',
+  dirname: __dirname + '/filterdir',
   filter: /(.+)\.js$/,
   excludeDirs: /^\.svn$/
 });
@@ -193,7 +193,7 @@ assert.ok(excludedSvn.sub);
  * Exclude .svn and sub dirs
  **/
 var excludedSvnAndSub = requireAll({
-  dirname: 'filterdir',
+  dirname: __dirname + '/filterdir',
   filter: /(.+)\.js$/,
   excludeDirs: /^(\.svn|sub)$/
 });
@@ -207,7 +207,7 @@ assert.equal(excludedSvnAndSub.sub, undefined);
  * Resolve test
  **/
 var resolvedValues = requireAll({
-  dirname: 'resolved',
+  dirname: __dirname + '/resolved',
   filter: /(.+)\.js$/,
   resolve: function(fn) {
     return fn('arg1', 'arg2');
@@ -223,7 +223,7 @@ assert.equal(resolvedValues.twoargs, 'arg2');
  **/
 var moduleInfos = [];
 var resolvedValues = requireAll({
-  dirname: 'resolved',
+  dirname: __dirname + '/resolved',
   filter: /(.+)\.js$/,
   map: function (name) {
     return name.replace(/([A-Za-z]+)/, function (m, c) {
@@ -248,10 +248,10 @@ assert.equal(moduleInfos[1].path, __dirname + '/' + 'resolved/twoargs.js');
 
 /**
  * TEST #11
- * Backwards compatibility test with absolute paths as dirname
+ * Relative dirname
  **/
 var unfiltered = requireAll({
-  dirname: __dirname + '/filterdir',
+  dirname: 'filterdir',
   filter: /(.+)\.js$/,
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -2,8 +2,12 @@ var assert = require('assert');
 var semver = require('semver');
 var requireAll = require('..');
 
+/**
+ * TEST #1
+ * Recursively load .js files from the `controller` folder that end with `Controller`
+ **/
 var controllers = requireAll({
-  dirname: __dirname + '/controllers',
+  dirname: 'controllers',
   filter: /(.+Controller)\.js$/
 });
 
@@ -28,8 +32,12 @@ assert.deepEqual(controllers, {
   }
 });
 
+/**
+ * TEST #2
+ * Non-recursively load .js files from the `controller` folder that end with `Controller`
+ **/
 var controllersTop = requireAll({
-  dirname: __dirname + '/controllers',
+  dirname: 'controllers',
   filter: /(.+Controller)\.js$/,
   recursive: false
 });
@@ -48,8 +56,13 @@ assert.deepEqual(controllersTop, {
   }
 });
 
+/**
+ * TEST #3
+ * Recursively load .js files from the `controller` folder that end with `Controller`
+ * Replace `-C` for `_c` in the property name using the map option
+ **/
 var controllersMap = requireAll({
-  dirname: __dirname + '/controllers',
+  dirname: 'controllers',
   filter: /(.+Controller)\.js$/,
   map: function (name) {
     return name.replace(/-([A-Z])/, function (m, c) {
@@ -79,9 +92,13 @@ assert.deepEqual(controllersMap, {
   }
 });
 
-
+/**
+ * TEST #4
+ * Recursively load .js files from the `controller` folder that end with `Controller`
+ * Replace `-C` for `_c` in the property name using the map option
+ **/
 controllersMap = requireAll({
-  dirname: __dirname + '/controllers',
+  dirname: 'controllers',
   filter: /(.+Controller)\.js$/,
   map: function (name) {
     return name.replace(/-([A-Za-z])/, function (m, c) {
@@ -111,43 +128,14 @@ assert.deepEqual(controllersMap, {
   }
 });
 
-controllersMap = requireAll({
-  dirname: __dirname + '/controllers',
-  filter: /(.+Controller)\.js$/,
-  map: function (name) {
-    return name.replace(/-([A-Za-z])/, function (m, c) {
-      return '_' + c.toLowerCase();
-    });
-  }
-});
-
-assert.deepEqual(controllersMap, {
-  main_controller: {
-    index: 1,
-    show: 2,
-    add: 3,
-    edit: 4
-  },
-
-  other_controller: {
-    index: 1,
-    show: 'nothing'
-  },
-
-  sub_dir: {
-    other_controller: {
-      index: 1,
-      show: 2
-    }
-  }
-});
-
-//
-// requiring json only became an option in 0.6+
-//
-if (semver.gt(process.version, 'v0.6.0')) {
+/**
+ * TEST #5
+ * Require JSON test
+ * Only became an option in 0.6+
+ **/
+if(semver.gt(process.version, 'v0.6.0')) {
   var mydir = requireAll({
-    dirname: __dirname + '/mydir'
+    dirname: 'mydir'
   });
 
   var mydir_contents = {
@@ -167,13 +155,17 @@ if (semver.gt(process.version, 'v0.6.0')) {
 
   assert.deepEqual(mydir, mydir_contents);
 
-  var defaults = requireAll(__dirname + '/mydir');
+  var defaults = requireAll('mydir');
 
   assert.deepEqual(defaults, mydir_contents);
 }
 
+/**
+ * TEST #6
+ * Exclude dirs false
+ **/
 var unfiltered = requireAll({
-  dirname: __dirname + '/filterdir',
+  dirname: 'filterdir',
   filter: /(.+)\.js$/,
   excludeDirs: false
 });
@@ -182,8 +174,12 @@ assert(unfiltered['.svn']);
 assert(unfiltered.root);
 assert(unfiltered.sub);
 
+/**
+ * TEST #7
+ * Exclude .svn dirs
+ **/
 var excludedSvn = requireAll({
-  dirname: __dirname + '/filterdir',
+  dirname: 'filterdir',
   filter: /(.+)\.js$/,
   excludeDirs: /^\.svn$/
 });
@@ -192,8 +188,12 @@ assert.equal(excludedSvn['.svn'], undefined);
 assert.ok(excludedSvn.root);
 assert.ok(excludedSvn.sub);
 
+/**
+ * TEST #8
+ * Exclude .svn and sub dirs
+ **/
 var excludedSvnAndSub = requireAll({
-  dirname: __dirname + '/filterdir',
+  dirname: 'filterdir',
   filter: /(.+)\.js$/,
   excludeDirs: /^(\.svn|sub)$/
 });
@@ -202,10 +202,14 @@ assert.equal(excludedSvnAndSub['.svn'], undefined);
 assert.ok(excludedSvnAndSub.root);
 assert.equal(excludedSvnAndSub.sub, undefined);
 
+/**
+ * TEST #9
+ * Resolve test
+ **/
 var resolvedValues = requireAll({
-  dirname: __dirname + '/resolved',
+  dirname: 'resolved',
   filter: /(.+)\.js$/,
-  resolve: function (fn) {
+  resolve: function(fn) {
     return fn('arg1', 'arg2');
   }
 });
@@ -213,10 +217,13 @@ var resolvedValues = requireAll({
 assert.equal(resolvedValues.onearg, 'arg1');
 assert.equal(resolvedValues.twoargs, 'arg2');
 
-// Tests that the name is converted by the map function and path is defined
+/**
+ * TEST #10
+ * Module info test, tests that the name is converted by the map function
+ **/
 var moduleInfos = [];
 var resolvedValues = requireAll({
-  dirname: __dirname + '/resolved',
+  dirname: 'resolved',
   filter: /(.+)\.js$/,
   map: function (name) {
     return name.replace(/([A-Za-z]+)/, function (m, c) {
@@ -238,3 +245,14 @@ assert.equal(moduleInfos[0].name, 'ONEARG');
 assert.equal(moduleInfos[0].path, __dirname + '/' + 'resolved/onearg.js');
 assert.equal(moduleInfos[1].name, 'TWOARGS');
 assert.equal(moduleInfos[1].path, __dirname + '/' + 'resolved/twoargs.js');
+
+/**
+ * TEST #11
+ * Backwards compatibility test with absolute paths as dirname
+ **/
+var unfiltered = requireAll({
+  dirname: __dirname + '/filterdir',
+  filter: /(.+)\.js$/,
+});
+
+assert(unfiltered, 'Absolute path backwards compatibility not working');

--- a/test/test.js
+++ b/test/test.js
@@ -235,6 +235,6 @@ var resolvedValues = requireAll({
 assert.equal(resolvedValues.ONEARG, 'arg1');
 assert.equal(resolvedValues.TWOARGS, 'arg2');
 assert.equal(moduleInfos[0].name, 'ONEARG');
-assert(moduleInfos[0].path, 'path undefined');
+assert.equal(moduleInfos[0].path, __dirname + '/' + 'resolved/onearg.js');
 assert.equal(moduleInfos[1].name, 'TWOARGS');
-assert(moduleInfos[1].path, 'path undefined');
+assert.equal(moduleInfos[1].path, __dirname + '/' + 'resolved/twoargs.js');

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,7 @@ var requireAll = require('..');
  * Recursively load .js files from the `controller` folder that end with `Controller`
  **/
 var controllers = requireAll({
-  dirname: __dirname + '/controllers',
+  dirname: 'controllers',
   filter: /(.+Controller)\.js$/
 });
 
@@ -37,7 +37,7 @@ assert.deepEqual(controllers, {
  * Non-recursively load .js files from the `controller` folder that end with `Controller`
  **/
 var controllersTop = requireAll({
-  dirname: __dirname + '/controllers',
+  dirname: 'controllers',
   filter: /(.+Controller)\.js$/,
   recursive: false
 });
@@ -62,7 +62,7 @@ assert.deepEqual(controllersTop, {
  * Replace `-C` for `_c` in the property name using the map option
  **/
 var controllersMap = requireAll({
-  dirname: __dirname + '/controllers',
+  dirname: 'controllers',
   filter: /(.+Controller)\.js$/,
   map: function (name) {
     return name.replace(/-([A-Z])/, function (m, c) {
@@ -98,7 +98,7 @@ assert.deepEqual(controllersMap, {
  * Replace `-C` for `_c` in the property name using the map option
  **/
 controllersMap = requireAll({
-  dirname: __dirname + '/controllers',
+  dirname: 'controllers',
   filter: /(.+Controller)\.js$/,
   map: function (name) {
     return name.replace(/-([A-Za-z])/, function (m, c) {
@@ -135,7 +135,7 @@ assert.deepEqual(controllersMap, {
  **/
 if(semver.gt(process.version, 'v0.6.0')) {
   var mydir = requireAll({
-    dirname: __dirname + '/mydir'
+    dirname: 'mydir'
   });
 
   var mydir_contents = {
@@ -165,7 +165,7 @@ if(semver.gt(process.version, 'v0.6.0')) {
  * Exclude dirs false
  **/
 var unfiltered = requireAll({
-  dirname: __dirname + '/filterdir',
+  dirname: 'filterdir',
   filter: /(.+)\.js$/,
   excludeDirs: false
 });
@@ -179,7 +179,7 @@ assert(unfiltered.sub);
  * Exclude .svn dirs
  **/
 var excludedSvn = requireAll({
-  dirname: __dirname + '/filterdir',
+  dirname: 'filterdir',
   filter: /(.+)\.js$/,
   excludeDirs: /^\.svn$/
 });
@@ -193,7 +193,7 @@ assert.ok(excludedSvn.sub);
  * Exclude .svn and sub dirs
  **/
 var excludedSvnAndSub = requireAll({
-  dirname: __dirname + '/filterdir',
+  dirname: 'filterdir',
   filter: /(.+)\.js$/,
   excludeDirs: /^(\.svn|sub)$/
 });
@@ -207,7 +207,7 @@ assert.equal(excludedSvnAndSub.sub, undefined);
  * Resolve test
  **/
 var resolvedValues = requireAll({
-  dirname: __dirname + '/resolved',
+  dirname: 'resolved',
   filter: /(.+)\.js$/,
   resolve: function(fn) {
     return fn('arg1', 'arg2');
@@ -223,7 +223,7 @@ assert.equal(resolvedValues.twoargs, 'arg2');
  **/
 var moduleInfos = [];
 var resolvedValues = requireAll({
-  dirname: __dirname + '/resolved',
+  dirname: 'resolved',
   filter: /(.+)\.js$/,
   map: function (name) {
     return name.replace(/([A-Za-z]+)/, function (m, c) {
@@ -248,10 +248,10 @@ assert.equal(moduleInfos[1].path, __dirname + '/' + 'resolved/twoargs.js');
 
 /**
  * TEST #11
- * Relative dirname
+ * Test backwards compatibility with absolute dirnames
  **/
 var unfiltered = requireAll({
-  dirname: 'filterdir',
+  dirname: __dirname + '/filterdir',
   filter: /(.+)\.js$/,
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -212,3 +212,30 @@ var resolvedValues = requireAll({
 
 assert.equal(resolvedValues.onearg, 'arg1');
 assert.equal(resolvedValues.twoargs, 'arg2');
+
+// Module info test, tests that the name is converted by the map function
+var moduleInfos = [];
+var resolvedValues = requireAll({
+  dirname: __dirname + '/resolved',
+  filter: /(.+)\.js$/,
+  map: function (name) {
+    return name.replace(/([A-Za-z]+)/, function (m, c) {
+      return c.toUpperCase();
+    });
+  },
+  resolve: function (fn, moduleInfo) {
+    moduleInfos.push(moduleInfo);
+    return fn('arg1', 'arg2');
+  }
+});
+
+assert.equal(resolvedValues.ONEARG, 'arg1');
+assert.equal(resolvedValues.TWOARGS, 'arg2');
+assert.equal(moduleInfos[0].name, 'ONEARG');
+assert(moduleInfos[0].dir, 'moduleInfo.filepath undefined');
+assert.equal(moduleInfos[0].file, 'onearg.js');
+assert(moduleInfos[0].path, 'moduleInfo.filepath undefined');
+assert.equal(moduleInfos[1].name, 'TWOARGS');
+assert(moduleInfos[1].dir, 'moduleInfo.filepath undefined');
+assert.equal(moduleInfos[1].file, 'twoargs.js');
+assert(moduleInfos[1].path, 'moduleInfo.filepath undefined');


### PR DESCRIPTION
I thought needing to specify the absolute path of the directory shouldn't be necessary.
So I added support for relative paths & backwards compatibility with the old absolute paths.