### PR TITLE
Supporting non-capturing groups on filter regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function requireAll(options) {
     var match = filename.match(filter);
     if (!match) return;
 
-    return match[1];
+    return match[1] || match[0];
   }
 
   var files = fs.readdirSync(dirname);

--- a/test/test.js
+++ b/test/test.js
@@ -79,6 +79,29 @@ assert.deepEqual(controllersMap, {
   }
 });
 
+var controllersMap = requireAll({
+  dirname: __dirname + '/controllers',
+  filter: /.+Controller\.js$/
+});
+
+assert.deepEqual(controllersMap, {
+  'main-Controller.js': {
+    index: 1,
+    show: 2,
+    add: 3,
+    edit: 4
+  },
+  'other-Controller.js': {
+   index: 1,
+   show: 'nothing'
+  },
+  'sub-dir': {
+    'other-Controller.js': {
+      index: 1,
+      show: 2
+    }
+  }
+});
 
 controllersMap = requireAll({
   dirname: __dirname + '/controllers',


### PR DESCRIPTION
If we want to support a regex in the filter it's not obvious to limit it to just capturing groups.